### PR TITLE
chore(release): use volta setup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 env:
-  PNPM_VERSION: 6.35.1
+  VOLTA_FEATURE_PNPM: 1
 
 jobs:
   release:
@@ -14,17 +14,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3.4.0
-      - uses: pnpm/action-setup@v2.2.4
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      - uses: volta-cli/action@d253558a6e356722728a10e9a469190de21a83ef # v4
+      - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3
         with:
-          version: ${{ env.PNPM_VERSION }}
+          path: "**/node_modules"
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
 
-      - uses: actions/setup-node@v3.6.0
-        with:
-          node-version: 12.x
-          cache: pnpm
-          registry-url: 'https://registry.npmjs.org'
-
-      - run: npm publish
+      - name: Set publishing config
+        run: pnpm config set '//registry.npmjs.org/:_authToken' "${NODE_AUTH_TOKEN}"
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+      - run: pnpm publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,4 +28,4 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
-      - run: pnpm publish
+      - run: pnpm publishPackage

--- a/package.json
+++ b/package.json
@@ -23,7 +23,10 @@
     "release": "release-it",
     "start": "ember serve",
     "test": "ember test",
-    "publish": "npm publish"
+    "publishPackage": "npm publish"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.6"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "lint:js:fix": "eslint . --fix",
     "release": "release-it",
     "start": "ember serve",
-    "test": "ember test"
+    "test": "ember test",
+    "publish": "npm publish"
   },
   "dependencies": {
     "ember-cli-babel": "^7.26.6"


### PR DESCRIPTION
- Uses volta for Release workflow
Aligns publish setup with how we do it for ESA https://github.com/mainmatter/ember-simple-auth/blob/master/.github/workflows/release.yml